### PR TITLE
Fix for proper currency wallet health assignment

### DIFF
--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/dto/response/CurrenciesResponse.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/dto/response/CurrenciesResponse.java
@@ -1,6 +1,7 @@
 package org.knowm.xchange.kucoin.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 import java.math.BigDecimal;
@@ -21,12 +22,16 @@ public class CurrenciesResponse {
 
     private String withdrawalMinFee;
 
+    @JsonProperty("isWithdrawEnabled")
     private boolean isWithdrawEnabled;
 
+    @JsonProperty("isDepositEnabled")
     private boolean isDepositEnabled;
 
+    @JsonProperty("isMarginEnabled")
     private boolean isMarginEnabled;
 
+    @JsonProperty("isDebitEnabled")
     private boolean isDebitEnabled;
 
 }


### PR DESCRIPTION
Response serialization is fixed( to avoid "is" prefix, should add explicit jsonproperty tag )