### PR TITLE
okex trade service fix

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/CancelOrderByInstrumentAndIdParams.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/CancelOrderByInstrumentAndIdParams.java
@@ -1,4 +1,0 @@
-package org.knowm.xchange.service.trade.params;
-
-public interface CancelOrderByInstrumentAndIdParams
-    extends CancelOrderByIdParams, CancelOrderByInstrument {}

--- a/xchange-okex/src/main/java/org/knowm/xchange/okex/v5/OkexAdapters.java
+++ b/xchange-okex/src/main/java/org/knowm/xchange/okex/v5/OkexAdapters.java
@@ -93,29 +93,12 @@ public class OkexAdapters {
         .build();
   }
 
-  public static String adaptOrderTypeToPositionEffect(OrderType orderType) {
-    switch (orderType) {
-      case BID:
-        return "long";
-
-      case ASK:
-        return "short";
-      case EXIT_ASK:
-        return "short";
-      case EXIT_BID:
-        return "long";
-    }
-    return null;
-  }
-
   public static OkexOrderRequest adaptOrder(LimitOrder order) {
-    String positionEffect = adaptOrderTypeToPositionEffect(order.getType());
-
     return OkexOrderRequest.builder()
         .instrumentId(adaptInstrumentId(order.getInstrument()))
         .tradeMode(order.getInstrument() instanceof CurrencyPair ? "cash" : "cross")
         .side(order.getType() == Order.OrderType.BID ? "buy" : "sell")
-        .posSide(positionEffect)
+        .posSide(null)
         .orderType("limit")
         .amount(order.getOriginalAmount().toString())
         .price(order.getLimitPrice().toString())

--- a/xchange-okex/src/main/java/org/knowm/xchange/okex/v5/dto/trade/OkexTradeParams.java
+++ b/xchange-okex/src/main/java/org/knowm/xchange/okex/v5/dto/trade/OkexTradeParams.java
@@ -1,4 +1,4 @@
-package org.knowm.xchange.okex.v5;
+package org.knowm.xchange.okex.v5.dto.trade;
 
 import org.knowm.xchange.instrument.Instrument;
 import org.knowm.xchange.service.trade.params.CancelOrderByIdParams;

--- a/xchange-okex/src/test/java/org/knowm/xchange/okex/v5/OkexExchangeIntegration.java
+++ b/xchange-okex/src/test/java/org/knowm/xchange/okex/v5/OkexExchangeIntegration.java
@@ -16,7 +16,6 @@ import org.knowm.xchange.ExchangeSpecification;
 import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.OpenOrders;
-import org.knowm.xchange.okex.v5.dto.trade.OkexTradeParams;
 import org.knowm.xchange.okex.v5.service.OkexTradeService;
 import org.knowm.xchange.service.trade.params.CancelOrderParams;
 
@@ -30,7 +29,7 @@ public class OkexExchangeIntegration {
   private static final String PASSPHRASE = "";
 
   @Test
-  public void testCreateExchangeShouldApplyDefaultSpecification() throws Exception {
+  public void testCreateExchangeShouldApplyDefaultSpecification() {
     ExchangeSpecification spec = new OkexExchange().getDefaultExchangeSpecification();
     final Exchange exchange = ExchangeFactory.INSTANCE.createExchange(spec);
 
@@ -43,7 +42,7 @@ public class OkexExchangeIntegration {
   }
 
   @Test
-  public void testCreateExchangeShouldApplyResilience() throws Exception {
+  public void testCreateExchangeShouldApplyResilience() {
     ExchangeSpecification spec = new OkexExchange().getDefaultExchangeSpecification();
     ExchangeSpecification.ResilienceSpecification resilienceSpecification =
         new ExchangeSpecification.ResilienceSpecification();

--- a/xchange-okex/src/test/java/org/knowm/xchange/okex/v5/OkexExchangeIntegration.java
+++ b/xchange-okex/src/test/java/org/knowm/xchange/okex/v5/OkexExchangeIntegration.java
@@ -16,6 +16,7 @@ import org.knowm.xchange.ExchangeSpecification;
 import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.OpenOrders;
+import org.knowm.xchange.okex.v5.dto.trade.OkexTradeParams;
 import org.knowm.xchange.okex.v5.service.OkexTradeService;
 import org.knowm.xchange.service.trade.params.CancelOrderParams;
 

--- a/xchange-okex/src/test/java/org/knowm/xchange/okex/v5/OkexTradeParams.java
+++ b/xchange-okex/src/test/java/org/knowm/xchange/okex/v5/OkexTradeParams.java
@@ -1,11 +1,12 @@
-package org.knowm.xchange.okex.v5.dto.trade;
+package org.knowm.xchange.okex.v5;
 
 import org.knowm.xchange.instrument.Instrument;
-import org.knowm.xchange.service.trade.params.CancelOrderByInstrumentAndIdParams;
+import org.knowm.xchange.service.trade.params.CancelOrderByIdParams;
+import org.knowm.xchange.service.trade.params.CancelOrderByInstrument;
 
 /** Author: Max Gao (gaamox@tutanota.com) Created: 10-06-2021 */
 public class OkexTradeParams {
-  public static class OkexCancelOrderParams implements CancelOrderByInstrumentAndIdParams {
+  public static class OkexCancelOrderParams implements CancelOrderByIdParams, CancelOrderByInstrument {
     public final Instrument instrument;
     public final String orderId;
 


### PR DESCRIPTION
@aligokalppeker  Simdilik hatali yeri cikardim. 

Ek olarak cancel order su sekilde kullaniliyor;

```
        LimitOrder makerLimitOrder = new LimitOrder(Order.OrderType.ASK, BigDecimal.valueOf(1.5), CurrencyPair.XRP_USDT, UUID.randomUUID().toString(), null, BigDecimal.valueOf(2));
        orderId = okexExchange.getTradeService().placeLimitOrder(makerLimitOrder);
        CancelOrderByInstrumentAndIdParams cancelOrderByInstrumentAndIdParams = new OkexTradeParams.OkexCancelOrderParams(CurrencyPair.XRP_USDT, orderId);
        boolean b = okexExchange.getTradeService().cancelOrder(cancelOrderByInstrumentAndIdParams);
```
Calistigini kontrol ettim.  getOpenOrders() da calisiyor.  


